### PR TITLE
Add HTTP routes to start and stop recording

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ hound = "3.4.0"
 chrono = "0.4.19"
 objc = { version = "0.2.7" }
 cocoa = "0.25.0"
+warp = "0.3"
 
 [build-dependencies]
 cc = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ chrono = "0.4.19"
 objc = { version = "0.2.7" }
 cocoa = "0.25.0"
 warp = "0.3"
+lazy_static = "1.4.0"
 
 [build-dependencies]
 cc = "1.0"


### PR DESCRIPTION
The commit introduces HTTP endpoints using the Warp library to manage voice recording. It adds a new dependency in Cargo.toml for the Warp library and modifies main.rs to create /start_recording and /stop_recording routes. The start_recording function is now asynchronous to allow non-blocking recording.